### PR TITLE
fix(@theme-ui/sidenav): move React to peerDependencies

### DIFF
--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -13,12 +13,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "react": "^16.8.6"
+  },
+  "devDependencies": {
+    "react": "^16.8.6"
+  },
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@mdx-js/react": "^1.0.21",
     "@types/mdx-js__react": "^1.5.1",
     "deepmerge": "^4.0.0",
-    "react": "^16.8.6",
     "theme-ui": "^0.4.0-alpha.3"
   },
   "keywords": [


### PR DESCRIPTION
During development of a library I was facing problems with "Invalid hook call" from React.
It turns out that the sidenav package leads to a second copy of React because it is declared as dependency.